### PR TITLE
fix: set `peerDependency` on `@capacitor/core` to `>=7.0.0`

### DIFF
--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -71,7 +71,7 @@
     "typescript": "~5.4.5"
   },
   "peerDependencies": {
-    "@capacitor/core": "next"
+    "@capacitor/core": ">=7.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",

--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/geolocation",
-  "version": "7.1.0-dev.1",
+  "version": "7.1.0-dev.2",
   "description": "Geolocation plugin for Capacitor",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
- Sets `peerDependency` on `@capacitor/core` to `>=7.0.0`, to match the previous version of the plugin (`@capacitor/geolocation@7.0.0`).