### PR TITLE
fix: make SPM use version 7 instead of main

### DIFF
--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["GeolocationPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
Using `branch: "main"` can cause problems if latest SPM published version is for Capacitor 6
This was previously addressed on capacitor-plugins repository but got undone on the plugin rewrite
https://github.com/ionic-team/capacitor-plugins/pull/2300