### PR TITLE
fix(android): Properly parsing number parameters

### DIFF
--- a/packages/capacitor-plugin/android/src/main/kotlin/com/capacitorjs/plugins/geolocation/GeolocationPlugin.kt
+++ b/packages/capacitor-plugin/android/src/main/kotlin/com/capacitorjs/plugins/geolocation/GeolocationPlugin.kt
@@ -326,13 +326,16 @@ class GeolocationPlugin : Plugin() {
      * @return IONGLOCLocationOptions object
      */
     private fun createOptions(call: PluginCall): IONGLOCLocationOptions {
-        val timeout = call.getLong("timeout", 10000) ?: 10000
-        val maximumAge = call.getLong("maximumAge", 0) ?: 0
+        val timeout = call.getNumber("timeout", 10000)
+        val maximumAge = call.getNumber("maximumAge", 0)
         val enableHighAccuracy = call.getBoolean("enableHighAccuracy", false) ?: false
-        val minimumUpdateInterval = call.getLong("minimumUpdateInterval", 5000) ?: 5000
+        val minimumUpdateInterval = call.getNumber("minimumUpdateInterval", 5000)
 
         val locationOptions = IONGLOCLocationOptions(timeout, maximumAge, enableHighAccuracy, minimumUpdateInterval)
 
         return locationOptions
     }
+
+    private fun PluginCall.getNumber(name: String, defaultValue: Long): Long =
+        getLong(name) ?: getInt(name)?.toLong() ?: defaultValue
 }

--- a/packages/example-app-capacitor/src/js/capacitor-welcome.js
+++ b/packages/example-app-capacitor/src/js/capacitor-welcome.js
@@ -64,6 +64,12 @@ window.customElements.define(
         <button id="check-permission" class="button">Check permission</button>
         <button id="request-permission" class="button">Request permission</button>
         <br><br>
+        <label for="timeoutInput">timeout: </label>
+        <input type="number" id="timeoutInput" name="timeoutInput"><br>
+        <label for="ageInput">maximumAge: </label>
+        <input type="number" id="ageInput" name="ageInput"><br>
+        <input type="checkbox" id="highaccuracyCheck" name="highaccuracyCheck" checked="true"">
+        <label for="highaccuracyCheck">enableHighAccuracy</label><br><br>
         <button id="current-location" class="button">Get Current (single) position</button>
         <br><br>
         <button id="watch-location" class="button">Watch position (updates)</button>
@@ -101,8 +107,9 @@ window.customElements.define(
 
       self.shadowRoot.querySelector('#current-location').addEventListener('click', async function (e) {
         try {
+          let options = createLocationOptions();
           const currentLocation = await Geolocation.getCurrentPosition(
-            { enableHighAccuracy: true }
+            options
           );
           const locationString = locationToString(currentLocation, '')
           alert(locationString)
@@ -115,8 +122,9 @@ window.customElements.define(
         let watchId = ""
         try {
           let shouldAppendWatchId = true
+          let options = createLocationOptions()
           watchId = await Geolocation.watchPosition(
-            { enableHighAccuracy: true },
+            options,
             (position, err) => {
               if (err) {
                 alert(`Error getting current position:\n\t code=${err.code}\n\t message=\"${err.message}\"`)
@@ -152,6 +160,20 @@ window.customElements.define(
         const wacthesList = self.shadowRoot.querySelector('#watch-position-updates-list');
         wacthesList.innerHTML = '';
       });
+
+      function createLocationOptions() {
+        const enableHighAccuracyValue = self.shadowRoot.getElementById('highaccuracyCheck').checked;
+        let options = { enableHighAccuracy: enableHighAccuracyValue }
+        const timeoutValue = self.shadowRoot.getElementById('timeoutInput').value;
+        if (timeoutValue) {
+          options.timeout = Number(timeoutValue);
+        }
+        const ageValue = self.shadowRoot.getElementById('ageInput').value;
+        if (ageValue) {
+          options.maximumAge = Number(ageValue);
+        }
+        return options
+      }
 
       function onWatchAdded(watchId) {
         // Append the watchId as a button to the list


### PR DESCRIPTION
## Description

Number attributes (`timeout`, `maximumAge`) were being assumed to be Long on Android, but Capacitor sends them as Int if they are small enough. This was causing the parameters to not be parsed correctly.

This PR addresses that by checking if the long result is null, and if so, getting the integer value instead.

## Context

Fixes https://github.com/ionic-team/capacitor-geolocation/issues/22

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Tested with the example app of this repo. This PR includes UI to be able to change the input arguments.
