### PR TITLE
fix(android): update Gradle and Kotlin configurations for compatibili…

### DIFF
--- a/packages/capacitor-plugin/android/build.gradle
+++ b/packages/capacitor-plugin/android/build.gradle
@@ -7,13 +7,13 @@ ext {
 }
 
 buildscript {
-    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.9.24'
+    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.9.25'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.1'
+        classpath 'com.android.tools.build:gradle:8.7.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
This PR resolves issues encountered during Gradle sync and build caused by outdated `kotlin_version` and incompatible `com.android.tools.build:gradle` versions.

### Changes:
- Updated Kotlin version to `1.9.25`
- Updated `com.android.tools.build:gradle` to `8.7.2`

### Why:
The previous configuration failed with newer Android Studio/AGP environments and broke compatibility with recent AndroidX core libraries. These updates align the plugin's build script with current standards and fix compatibility issues.

Tested successfully on Android Studio with Gradle 8+ and AGP 8.7.2.