### PR TITLE
docs(ios): Add context for background usage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Apple requires privacy descriptions to be specified in `Info.plist` for location
 - `NSLocationAlwaysAndWhenInUseUsageDescription` (`Privacy - Location Always and When In Use Usage Description`)
 - `NSLocationWhenInUseUsageDescription` (`Privacy - Location When In Use Usage Description`)
 
+> [!NOTE]
+> This Capacitor plugin does not support background geolocation directly. However, it relies on
+> [`ion-ios-geolocation`](https://github.com/ionic-team/ion-ios-geolocation), which can report
+> location in the background. As a result, Apple requires you to include a
+> `NSLocationAlwaysAndWhenInUseUsageDescription` entry in your `Info.plist`. Since this permission
+> prompt won’t appear to users, you can safely use the same description string as for
+> `NSLocationWhenInUseUsageDescription`.
+
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode
 
 ## Android


### PR DESCRIPTION
## Description

Closes #26.

This adds a quick note to the README for why a background location access usage description is required by iOS even though background location isn't directly possible with this Capacitor plugin.

Open to suggestions for better wording/placement.

## Context
I was a little confused when I received a warning email about this from Apple. It wasn't clear to me why I would have to add a description for something my app doesn't do, so I'm hoping  makes things clearer for others. See #26.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [ ] JavaScript

## Tests
This is a documentation change; no testing applicable.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [x] Documentation has been updated accordingly
