### PR TITLE
fix(ios): handle location watch callbacks recovery after backgrounding

### DIFF
--- a/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationCallbackManager.swift
+++ b/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationCallbackManager.swift
@@ -110,6 +110,15 @@ final class GeolocationCallbackManager {
     func sendError(_ error: GeolocationError) {
         createPluginResult(status: .error(error.toCodeMessagePair()))
     }
+
+    func sendLocationCallbacksError(_ error: GeolocationError) {
+        // Send error only to single location request callbacks, not watch callbacks
+        let errorModel = error.toCodeMessagePair()
+        locationCallbacks.forEach { call in
+            call.reject(errorModel.1, errorModel.0)
+        }
+        clearLocationCallbacks()
+    }
 }
 
 private enum CallResultStatus {

--- a/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationCallbackManager.swift
+++ b/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationCallbackManager.swift
@@ -110,15 +110,6 @@ final class GeolocationCallbackManager {
     func sendError(_ error: GeolocationError) {
         createPluginResult(status: .error(error.toCodeMessagePair()))
     }
-
-    func sendLocationCallbacksError(_ error: GeolocationError) {
-        // Send error only to single location request callbacks, not watch callbacks
-        let errorModel = error.toCodeMessagePair()
-        locationCallbacks.forEach { call in
-            call.reject(errorModel.1, errorModel.0)
-        }
-        clearLocationCallbacks()
-    }
 }
 
 private enum CallResultStatus {

--- a/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
@@ -36,17 +36,15 @@ public class GeolocationPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc private func appDidBecomeActive() {
-        if let hasWatchCallbacks = callbackManager?.watchCallbacks.isEmpty, !hasWatchCallbacks {
+        if let watchCallbacksEmpty = callbackManager?.watchCallbacks.isEmpty, !watchCallbacksEmpty {
             print("App became active. Restarting location monitoring for watch callbacks.")
             locationCancellable?.cancel()
             locationCancellable = nil
             locationInitialized = false
             
             locationService?.stopMonitoringLocation()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                self.locationService?.startMonitoringLocation()
-                self.bindLocationPublisher()
-            }
+            locationService?.startMonitoringLocation()
+            bindLocationPublisher()
         }
     }
 

--- a/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
@@ -148,8 +148,7 @@ private extension GeolocationPlugin {
                 
                 if case IONGLOCLocationError.locationUnavailable = error {
                     print("Location unavailable (likely due to backgrounding). Keeping watch callbacks alive.")
-                    // Send error only to getCurrentPosition, keep watchPosition alive
-                    self?.callbackManager?.sendLocationCallbacksError(.positionUnavailable)
+                    self?.callbackManager?.sendError(.positionUnavailable)
                     return Empty<IONGLOCPositionModel, Never>()
                         .eraseToAnyPublisher()
                 } else {

--- a/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
@@ -1,5 +1,6 @@
 import Capacitor
 import IONGeolocationLib
+import UIKit
 
 import Combine
 
@@ -17,6 +18,7 @@ public class GeolocationPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private var locationService: (any IONGLOCService)?
     private var cancellables = Set<AnyCancellable>()
+    private var locationCancellable: AnyCancellable?
     private var callbackManager: GeolocationCallbackManager?
     private var statusInitialized = false
     private var locationInitialized: Bool = false
@@ -24,6 +26,32 @@ public class GeolocationPlugin: CAPPlugin, CAPBridgedPlugin {
     override public func load() {
         self.locationService = IONGLOCManagerWrapper()
         self.callbackManager = .init(capacitorBridge: bridge)
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    @objc private func appDidBecomeActive() {
+        if let hasWatchCallbacks = callbackManager?.watchCallbacks.isEmpty, !hasWatchCallbacks {
+            print("App became active. Restarting location monitoring for watch callbacks.")
+            locationCancellable?.cancel()
+            locationCancellable = nil
+            locationInitialized = false
+            
+            locationService?.stopMonitoringLocation()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.locationService?.startMonitoringLocation()
+                self.bindLocationPublisher()
+            }
+        }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     @objc func getCurrentPosition(_ call: CAPPluginCall) {
@@ -49,6 +77,9 @@ public class GeolocationPlugin: CAPPlugin, CAPBridgedPlugin {
 
         if (callbackManager?.watchCallbacks.isEmpty) ?? false {
             locationService?.stopMonitoringLocation()
+            locationCancellable?.cancel()
+            locationCancellable = nil
+            locationInitialized = false
         }
 
         callbackManager?.sendSuccess(call)
@@ -113,18 +144,25 @@ private extension GeolocationPlugin {
     func bindLocationPublisher() {
         guard !locationInitialized else { return }
         locationInitialized = true
-        locationService?.currentLocationPublisher
-            .sink(receiveCompletion: { [weak self] completion in
-                if case .failure(let error) = completion {
-                    // publisher should be re-observed in the next plugin call
-                    self?.locationInitialized = false
-                    print("An error was found while retrieving the location: \(error)")
+        locationCancellable = locationService?.currentLocationPublisher
+            .catch { [weak self] error -> AnyPublisher<IONGLOCPositionModel, Never> in
+                print("An error was found while retrieving the location: \(error)")
+                
+                if case IONGLOCLocationError.locationUnavailable = error {
+                    print("Location unavailable (likely due to backgrounding). Keeping watch callbacks alive.")
+                    // Send error only to getCurrentPosition, keep watchPosition alive
+                    self?.callbackManager?.sendLocationCallbacksError(.positionUnavailable)
+                    return Empty<IONGLOCPositionModel, Never>()
+                        .eraseToAnyPublisher()
+                } else {
                     self?.callbackManager?.sendError(.positionUnavailable)
+                    return Empty<IONGLOCPositionModel, Never>()
+                        .eraseToAnyPublisher()
                 }
-            }, receiveValue: { [weak self] position in
+            }
+            .sink(receiveValue: { [weak self] position in
                 self?.callbackManager?.sendSuccess(with: position)
             })
-            .store(in: &cancellables)
     }
 
     func requestLocationAuthorisation(type requestType: IONGLOCAuthorisationRequestType) {


### PR DESCRIPTION
## Description
Fixes #19 

This PR fixes iOS `watchPosition` recovery after backgrounding the app. Previously the plugin would throw an error and stop monitoring location updates. Now it will handle the error gracefully and restart the monitoring when the app becomes active again.

## Context
https://github.com/ionic-team/capacitor-geolocation/issues/19

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [X] iOS
- [ ] JavaScript

## Tests
Tested with https://github.com/nharrer/ionic-geo-location
