### PR TITLE
fix(ios): Simplify SPM usage

### DIFF
--- a/.github/actions/prepare-example-app/action.yml
+++ b/.github/actions/prepare-example-app/action.yml
@@ -1,0 +1,22 @@
+name: 'Prepare Example app'
+description: 'Does necessary pre-work for the example app to compile natively'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Build plugin'
+      working-directory: ./packages/capacitor-plugin
+      shell: bash
+      run: npm run build
+    - name: 'Install example app dependencies'
+      working-directory: ./packages/example-app-capacitor
+      shell: bash
+      run: npm i
+    - name: 'Build Web example app'
+      working-directory: ./packages/example-app-capacitor
+      shell: bash
+      run: npm run build
+    - name: 'Sync example app native platforms'
+      working-directory: ./packages/example-app-capacitor
+      shell: bash
+      run: npx cap sync

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,7 +16,7 @@ jobs:
     needs: 'setup'
     uses: ./.github/workflows/reusable_build.yml
 
-  verify-plugin:
+  verify-plugin-android:
     needs: ['setup', 'lint', 'build']
     runs-on: 'macos-15'
     timeout-minutes: 30
@@ -24,33 +24,46 @@ jobs:
       - uses: actions/checkout@v4
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
-      - name: 'Verify iOS + Android + Web'
+      - name: 'Verify Android'
         working-directory: ./packages/capacitor-plugin
-        run: npm run verify
+        run: npm run verify:android
 
-  build-example-app:
-    needs: ['verify-plugin']
+  verify-plugin-ios:
+    needs: ['setup', 'lint', 'build']
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
-      - name: 'Build plugin'
+      - name: 'Verify iOS'
         working-directory: ./packages/capacitor-plugin
-        run: npm run build
-      - name: 'Install example app dependencies'
-        working-directory: ./packages/example-app-capacitor
-        run: npm i
-      - name: 'Build Web example app'
-        working-directory: ./packages/example-app-capacitor
-        run: npm run build
-      - name: 'Sync example app native platforms'
-        working-directory: ./packages/example-app-capacitor
-        run: npx cap sync
+        run: npm run verify:ios
+
+  build-example-app-android:
+    needs: ['verify-plugin-ios', 'verify-plugin-android']
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+      - name: 'Prepare example app'
+        uses: ./.github/actions/prepare-example-app
       - name: 'Build Android example app'
         working-directory: ./packages/example-app-capacitor/android
         run: ./gradlew clean assembleDebug
+    
+  build-example-app-ios:
+    needs: ['verify-plugin-ios', 'verify-plugin-android']
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+      - name: 'Prepare example app'
+        uses: ./.github/actions/prepare-example-app
       - name: 'Build iOS example app'
         working-directory: ./packages/example-app-capacitor/ios/App
         run: xcodebuild clean build -workspace App.xcworkspace -scheme App CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -10,20 +10,16 @@ let package = Package(
             targets: ["GeolocationPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
+        .package(url: "https://github.com/ionic-team/ion-ios-geolocation.git", from: "1.0.2")
     ],
     targets: [
-        .binaryTarget(
-            name: "IONGeolocationLib",
-            url: "https://github.com/ionic-team/ion-ios-geolocation/releases/download/1.0.1/IONGeolocationLib.zip",
-            checksum: "80e0283964bce3c5d05f61ff4acf4e029305f58d1699a7f16453058ba876bc21" // sha-256
-        ),
         .target(
             name: "GeolocationPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                "IONGeolocationLib"
+                .product(name: "IONGeolocationLib", package: "ion-ios-geolocation")
             ],
             path: "ios/Sources/GeolocationPlugin"),
         .testTarget(


### PR DESCRIPTION
## Description

This PR updates the SPM declaration of the iOS FileViewer native library to be retrieved from GitHub directly instead of relying on a binary target.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-4427

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests

You can still test with the iOS example app to confirm that CocoaPods is working. In CI, `npm run verify:ios` builds the plugin with SPM.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
