### PR TITLE
URGENT fix(ios): honor maximumAge in getCurrentPosition instead of returning stale cached positions

### DIFF
--- a/ios/Sources/GeolocationPlugin/GeolocationCallbackManager.swift
+++ b/ios/Sources/GeolocationPlugin/GeolocationCallbackManager.swift
@@ -25,6 +25,7 @@ final class GeolocationCallbackManager {
     private(set) var locationCallbacks: [CAPPluginCall]
     private(set) var watchCallbacks: [String: CAPPluginCall]
     private(set) var timeout: Int?
+    private(set) var maximumAge: Double?
     private let capacitorBridge: CAPBridgeProtocol?
 
     private var allCallbackGroups: [GeolocationCallbackGroup] {
@@ -55,6 +56,7 @@ final class GeolocationCallbackManager {
         locationCallbacks.append(call)
         let timeout = call.getInt(Constants.Arguments.timeout)
         self.timeout = timeout
+        self.maximumAge = call.getDouble(Constants.Arguments.maximumAge) ?? 0
     }
 
     func addWatchCallback(_ watchId: String, capacitorCall call: CAPPluginCall) {
@@ -105,6 +107,11 @@ final class GeolocationCallbackManager {
 
     func sendSuccess(with position: IONGLOCPositionModel) {
         createPluginResult(status: .success(position.toJSObject()))
+    }
+
+    func sendWatchSuccess(with position: IONGLOCPositionModel) {
+        guard let watchGroup = allCallbackGroups.first(where: { $0.type == .watch }) else { return }
+        send(.success(position.toJSObject()), to: watchGroup)
     }
 
     func sendError(_ call: CAPPluginCall, error: GeolocationError) {

--- a/ios/Sources/GeolocationPlugin/GeolocationConstants.swift
+++ b/ios/Sources/GeolocationPlugin/GeolocationConstants.swift
@@ -2,7 +2,16 @@ enum Constants {
     enum Arguments {
         static let enableHighAccuracy = "enableHighAccuracy"
         static let id = "id"
+        static let maximumAge = "maximumAge"
         static let timeout = "timeout"
+    }
+
+    enum SingleLocationRequest {
+        /// A position younger than this is treated as a live fix rather than a cached one,
+        /// regardless of `maximumAge`. CLLocation timestamps lag delivery by the acquisition
+        /// time, so `maximumAge: 0` (the default, meaning "no cached positions") must still
+        /// accept freshly acquired fixes.
+        static let freshnessThresholdInMilliseconds: Double = 5000
     }
 
     enum AuthorisationStatus {

--- a/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
+++ b/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
@@ -162,7 +162,7 @@ private extension GeolocationPlugin {
                 }
             }
             .sink(receiveValue: { [weak self] position in
-                self?.callbackManager?.sendSuccess(with: position)
+                self?.handleReceivedPosition(position)
             })
 
         timeoutCancellable = locationService?.locationTimeoutPublisher
@@ -173,6 +173,40 @@ private extension GeolocationPlugin {
                     self?.callbackManager?.sendError(.positionUnavailable)
                 }
             })
+    }
+
+    /// Routes a position received from the location service to the pending callbacks,
+    /// enforcing `maximumAge` for `getCurrentPosition` calls: a cached position older
+    /// than `maximumAge` (e.g. the system's last known location from before the device
+    /// moved) must not satisfy them, so they are kept pending while a fresh position
+    /// is acquired. Watch callbacks always receive the update.
+    func handleReceivedPosition(_ position: IONGLOCPositionModel) {
+        guard let callbackManager else { return }
+        let hasSingleLocationRequests = !callbackManager.locationCallbacks.isEmpty
+
+        if hasSingleLocationRequests, isStaleForSingleLocationRequests(position) {
+            callbackManager.sendWatchSuccess(with: position)
+            if callbackManager.watchCallbacks.isEmpty {
+                // No watch is keeping monitoring alive, so request continuous updates to
+                // obtain a fresh position; also re-arms the timeout timer, which was
+                // cancelled when the stale position was delivered.
+                locationService?.startMonitoringLocation(options: IONGLOCRequestOptionsModel(timeout: callbackManager.timeout))
+            }
+            return
+        }
+
+        callbackManager.sendSuccess(with: position)
+
+        if hasSingleLocationRequests, callbackManager.watchCallbacks.isEmpty {
+            // Stop any monitoring started above solely to satisfy the single requests.
+            locationService?.stopMonitoringLocation()
+        }
+    }
+
+    func isStaleForSingleLocationRequests(_ position: IONGLOCPositionModel) -> Bool {
+        let ageInMilliseconds = Date().timeIntervalSince1970 * 1000 - position.timestamp
+        let maximumAge = callbackManager?.maximumAge ?? 0
+        return ageInMilliseconds > max(maximumAge, Constants.SingleLocationRequest.freshnessThresholdInMilliseconds)
     }
 
     func requestLocationAuthorisation(type requestType: IONGLOCAuthorisationRequestType) {


### PR DESCRIPTION
## Description

On iOS, `getCurrentPosition` ignores the `maximumAge` option entirely and can resolve with a stale cached position. This PR makes the iOS implementation honor `maximumAge` as documented (and as Android and Web already do): a position older than `maximumAge` no longer satisfies `getCurrentPosition` — the call stays pending while a fresh position is acquired (falling back to continuous updates when needed), still bounded by the existing `timeout` handling.

Details of the change:

- `maximumAge` is now read from `getCurrentPosition` calls (stored alongside the existing shared `timeout`, same last-caller-wins semantics).
- Positions delivered by the location service are checked against `maximumAge` before resolving pending single-location calls. Because CLLocation timestamps lag delivery by the acquisition time, positions younger than a 5s freshness threshold are always accepted, so the default `maximumAge: 0` keeps resolving with freshly acquired fixes.
- When a stale position is rejected and no watch is running, the plugin starts monitoring to force a fresh fix (re-arming the timeout timer, which the stale delivery had cancelled) and stops monitoring again once the request is satisfied. If a watch is already running, the next live update resolves the call.
- Watch callbacks are unaffected: they continue to receive every update, including the ones rejected for single requests.

## Context

There are two ways iOS currently hands back stale coordinates:

1. `CLLocationManager.requestLocation()` frequently delivers the system's last known location — taken minutes earlier, before the device moved — and nothing checks its timestamp.
2. Since IONGeolocationLib 2.x, `requestSingleLocation` returns the in-memory `currentLocation` verbatim whenever monitoring is active, with no freshness check at all.

Either way the position carries its original (good) accuracy value, so callers have no signal that the coordinates are outdated. In our production home-care app, caregivers clocking in at a patient's home get positions 1.5–3 miles away — reported as `accuracy: ~16m` — because the fix predates their drive over.

This is very likely the same root cause behind #68 and #69 ("wrong coordinates on iOS, fine on Android/Web"), both closed for lack of response. The answer to the question asked there ("are you receiving outdated location?") is yes: the coordinates are outdated, and only `position.timestamp` reveals it.

## Type of changes

- [x] Fix (non-breaking change which fixes an issue)

## Platforms affected

- [x] iOS

## Tests

- `npm run verify:ios` (xcodebuild) builds successfully.
- SwiftLint: no new violations (the two `nesting` warnings on `GeolocationConstants.swift` pre-date this change).
- The existing iOS test target is a template stub that references a class that no longer exists, so no unit tests were added here; happy to add coverage (e.g. via an injectable `IONGLOCService` fake) if you can point me at the preferred approach.
- Manual verification in a production app: with this patch, a `getCurrentPosition` call issued right after arriving at a new location waits for a live fix instead of resolving with the pre-drive cached position.

## Screenshots (if appropriate)

## Checklist

- [x] Code follows code style of this project
