### PR TITLE
chore: update plugin native android dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,8 +4,8 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
-    playServicesLocationVersion = project.hasProperty('playServicesLocationVersion') ? rootProject.ext.playServicesLocationVersion : '21.3.0'
-    kotlinxCoroutinesVersion = project.hasProperty('kotlinxCoroutinesVersion') ? rootProject.ext.kotlinxCoroutinesVersion : '1.10.2'
+    playServicesLocationVersion = project.hasProperty('playServicesLocationVersion') ? rootProject.ext.playServicesLocationVersion : '21.4.0'
+    kotlinxCoroutinesVersion = project.hasProperty('kotlinxCoroutinesVersion') ? rootProject.ext.kotlinxCoroutinesVersion : '1.11.0'
 }
 
 buildscript {
@@ -80,7 +80,7 @@ dependencies {
     implementation("io.ionic.libs:iongeolocation-android:2.2.1")
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
 
-    implementation 'com.google.code.gson:gson:2.13.2'
+    implementation 'com.google.code.gson:gson:2.14.0'
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$kotlinxCoroutinesVersion")
     implementation "com.google.android.gms:play-services-location:$playServicesLocationVersion"
 

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -22,16 +22,16 @@
     },
     "..": {
       "name": "@capacitor/geolocation",
-      "version": "8.2.0",
+      "version": "8.2.1-next.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/synapse": "^1.0.4"
       },
       "devDependencies": {
-        "@capacitor/android": "^8.0.0",
-        "@capacitor/core": "^8.0.0",
+        "@capacitor/android": "next",
+        "@capacitor/core": "next",
         "@capacitor/docgen": "^0.3.0",
-        "@capacitor/ios": "^8.0.0",
+        "@capacitor/ios": "next",
         "@ionic/eslint-config": "^0.4.0",
         "@ionic/prettier-config": "^4.0.0",
         "@ionic/swiftlint-config": "^2.0.0",
@@ -51,7 +51,7 @@
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
+        "@capacitor/core": ">=9.0.0-alpha.5"
       }
     },
     "node_modules/@capacitor/android": {


### PR DESCRIPTION
## Description

Update native android dependencies for the geolocation plugin, outside the ones covered by `variables.gradle` (those were updated in a previous PR). We've done similar work [last year for Cap 8](https://github.com/ionic-team/capacitor-geolocation/pull/61), this is an equivalent PR but for Cap 9.

## Context

Internal Jira Reference: https://outsystemsrd.atlassian.net/browse/RMET-5329

ℹ️ Out-of-scope: `classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'` update - that will be in a separate task / PR.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)
- [x] Other

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Tested with the capacitor app inside this repo, everything still works fine.
