### PR TITLE
fix: improve location retrieval reliability

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,7 +81,7 @@ dependencies {
         implementation project(':capacitor-android')
     }
 
-    implementation("io.ionic.libs:iongeolocation-android:2.2.1")
+    implementation("io.ionic.libs:iongeolocation-android:2.2.2")
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
 
     implementation 'com.google.code.gson:gson:2.13.2'

--- a/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
+++ b/ios/Sources/GeolocationPlugin/GeolocationPlugin.swift
@@ -150,6 +150,9 @@ private extension GeolocationPlugin {
         locationCancellable = locationService?.currentLocationPublisher
             .catch { [weak self] error -> AnyPublisher<IONGLOCPositionModel, Never> in
                 print("An error was found while retrieving the location: \(error)")
+                // A failure terminates this subscription; re-bind or later callbacks are dropped. RMET-5383
+                self?.locationInitialized = false
+                self?.bindLocationPublisher()
 
                 if case IONGLOCLocationError.locationUnavailable = error {
                     print("Location unavailable (likely due to backgrounding). Keeping watch callbacks alive.")


### PR DESCRIPTION
## Description
Picks up the Android library fix released in 2.2.2, where the enable-location dialog result only reached the newest request and left earlier ones waiting forever.

Also brings over the iOS fix from the Cordova plugin, since both share that code. One failed location attempt used to break every attempt after it until the app restarted.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-5383
https://github.com/ionic-team/cordova-outsystems-geolocation/pull/26
https://github.com/ionic-team/ion-android-geolocation/pull/14

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [X] iOS
- [ ] JavaScript