### PR TITLE
fix(android): only apply kotlin-android plugin if not already applied

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,9 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
     apply plugin: 'io.github.gradle-nexus.publish-plugin'
     apply from: file('../scripts/android/publish-root.gradle')


### PR DESCRIPTION
Guards the explicit `apply plugin: 'kotlin-android'` behind a check for an existing `kotlin` extension. Under AGP 9, the Android/Kotlin toolchain can already register the `kotlin` extension before this plugin's build.gradle runs, so the unconditional apply fails with:

`Failed to apply plugin 'kotlin-android'. > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.`