### PR TITLE
docs: fix unclosed admonitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ location in the background. As a result, Apple requires you to include a
 prompt won’t appear to users, you can safely use the same description string as for
 `NSLocationWhenInUseUsageDescription`.
 
-:::info
+:::
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode
 
@@ -46,7 +46,7 @@ The first two permissions ask for location data, both fine and coarse, and the l
 
 If you only require approximate location (variable accuracy but usually around 2 kilometers), you may just declare `ACCESS_COARSE_LOCATION` and `<uses-feature`, and use `enableHighAccuracy=false` when requesting location
 
-:::note
+:::
 
 Read about [Setting Permissions](https://capacitorjs.com/docs/android/configuration#setting-permissions) in the [Android Guide](https://capacitorjs.com/docs/android) for more information on setting Android permissions.
 


### PR DESCRIPTION
Closes https://github.com/ionic-team/capacitor-geolocation/issues/98

This will need a separate PR for https://github.com/ionic-team/capacitor-docs to fix the issue in the website, which will be

I have tested the fix locally and the boxes are now rendered correctly.

<img width="1360" height="985" alt="Screenshot 2026-08-13 at 12 21 40" src="https://github.com/user-attachments/assets/e296b384-70ee-43a4-8a14-9920e85239f1" />
