### PR TITLE
chore: update eslint to v10 and @ionic/eslint-config to v0.5.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-build
-dist
-example-app

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,16 @@
+const ionic = require('@ionic/eslint-config/recommended');
+
+module.exports = [
+  {
+    ignores: [
+      // eslint . --ext ts linted TypeScript only
+      '**/*.js',
+      '**/*.mjs',
+      '**/*.cjs',
+      '**/build/**',
+      '**/dist/**',
+      '**/example-app/**',
+    ],
+  },
+  ...ionic,
+];

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api GeolocationPlugin --output-readme README.md --output-json dist/docs.json",
@@ -54,7 +54,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "^0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "@semantic-release/changelog": "^6.0.3",
@@ -63,7 +63,7 @@
     "@semantic-release/github": "^12.0.2",
     "@semantic-release/npm": "^13.1.2",
     "@types/node": "^24.10.1",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.2",
@@ -77,9 +77,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "^0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
## Description
Moves this repo to ESLint 10 and `@ionic/eslint-config` v0.5. The `eslintConfig` block and `.eslintignore` are replaced by an `eslint.config.cjs`, and `--ext ts` is dropped from the lint script since flat config ignores it.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [X] Other (CI, chores, etc.)

## Rationale / Problems Fixed
https://outsystemsrd.atlassian.net/browse/RMET-4734

## Platforms Affected
- [ ] Android
- [ ] iOS
- [X] Web

## Notes
Needs `@ionic/eslint-config@0.5.0` published before merge; run `npm install` to refresh the lockfile.
